### PR TITLE
Feat: User 엔티티 수정, Dto 구현

### DIFF
--- a/src/main/java/com/dragon/stepbystep/domain/User.java
+++ b/src/main/java/com/dragon/stepbystep/domain/User.java
@@ -1,6 +1,5 @@
 package com.dragon.stepbystep.domain;
 
-import com.dragon.stepbystep.domain.BaseTimeEntity;
 import com.dragon.stepbystep.domain.enums.GenderType;
 import com.dragon.stepbystep.domain.enums.UserStatus;
 import jakarta.persistence.*;
@@ -18,7 +17,7 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private String passwordHash;
 
-    @Column(length = 50, nullable = false, unique = true)
+    @Column(length = 20, nullable = false, unique = true)
     private String nickname;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/dragon/stepbystep/domain/enums/UserStatus.java
+++ b/src/main/java/com/dragon/stepbystep/domain/enums/UserStatus.java
@@ -2,7 +2,6 @@ package com.dragon.stepbystep.domain.enums;
 
 public enum UserStatus {
     ACTIVE("활동"),
-    SUSPENDED("정지"),
     DELETED("탈퇴");
 
     private final String displayName;

--- a/src/main/java/com/dragon/stepbystep/dto/UserRegisterDto.java
+++ b/src/main/java/com/dragon/stepbystep/dto/UserRegisterDto.java
@@ -1,0 +1,35 @@
+package com.dragon.stepbystep.dto;
+
+import com.dragon.stepbystep.domain.User;
+import com.dragon.stepbystep.domain.enums.GenderType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserRegisterDto {
+
+    private String email;
+
+    private String password;
+
+    private String nickname;
+
+    private String gender;
+
+    private int birthyear;
+
+    public User toEntity(String encodedPassword){
+        User user = new User();
+        user.setEmail(this.email);
+        user.setPasswordHash(this.password);
+        user.setNickname(this.nickname);
+        user.setGender(GenderType.valueOf(gender));
+        user.setBirthyear(this.birthyear);
+        return user;
+    }
+}

--- a/src/main/java/com/dragon/stepbystep/dto/UserResponseDto.java
+++ b/src/main/java/com/dragon/stepbystep/dto/UserResponseDto.java
@@ -1,0 +1,31 @@
+package com.dragon.stepbystep.dto;
+
+import com.dragon.stepbystep.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserResponseDto {
+
+    private String email;
+
+    private String nickname;
+
+    private String gender;
+
+    private int birthyear;
+
+    public static UserResponseDto fromEntity(User user) {
+        return UserResponseDto.builder()
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .gender(user.getGender().toString())
+                .birthyear(user.getBirthyear())
+                .build();
+    }
+}

--- a/src/main/java/com/dragon/stepbystep/dto/UserUpdateDto.java
+++ b/src/main/java/com/dragon/stepbystep/dto/UserUpdateDto.java
@@ -1,0 +1,31 @@
+package com.dragon.stepbystep.dto;
+
+import com.dragon.stepbystep.domain.User;
+import com.dragon.stepbystep.domain.enums.GenderType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserUpdateDto {
+
+    private String nickname;
+
+    private String gender;
+
+    private int birthyear;
+
+    public User toEntity(){
+        User user = new User();
+        user.setEmail(null);
+        user.setPasswordHash(null);
+        user.setNickname(this.nickname);
+        user.setGender(GenderType.valueOf(gender));
+        user.setBirthyear(this.birthyear);
+        return user;
+    }
+}

--- a/src/main/java/com/dragon/stepbystep/repository/UserRepository.java
+++ b/src/main/java/com/dragon/stepbystep/repository/UserRepository.java
@@ -1,0 +1,16 @@
+package com.dragon.stepbystep.repository;
+
+import com.dragon.stepbystep.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, String> {
+
+    Optional<User> findByEmail(String email);
+
+    boolean existsByEmail(String email);
+    boolean existsByNickname(String nickname);
+}


### PR DESCRIPTION
### 🛠 PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타: 

### 🔀 반영 브랜치
> ex) `feat/user` → `main`

### 📌 작업 상세 내용
- user 엔티티의 닉네임 도메인 글자 수 20자로 수정
- UserDto 생성

### 📎 기타 참고 사항
> 리뷰어가 참고해야 할 내용이 있다면 적어주세요.
